### PR TITLE
Fix CRT warnings and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ build/
 build_xcode/
 skia/win32/
 skia/win64/
+Makefile
 
 bin/
 bin-int/

--- a/core/save-bmp.cpp
+++ b/core/save-bmp.cpp
@@ -1,5 +1,7 @@
 
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 
 #include "save-bmp.h"
 

--- a/core/save-tiff.cpp
+++ b/core/save-tiff.cpp
@@ -1,5 +1,7 @@
 
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 
 #include "save-tiff.h"
 

--- a/core/shape-description.cpp
+++ b/core/shape-description.cpp
@@ -1,5 +1,8 @@
 
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include "shape-description.h"
 
 namespace msdfgen {

--- a/ext/import-svg.cpp
+++ b/ext/import-svg.cpp
@@ -1,6 +1,12 @@
 
+#ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
+#endif
+
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include "import-svg.h"
 
 #include <cstdio>

--- a/main.cpp
+++ b/main.cpp
@@ -8,8 +8,14 @@
 
 #ifdef MSDFGEN_STANDALONE
 
+#ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
+#endif
+
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include <cstdio>
 #include <cmath>
 #include <cstring>


### PR DESCRIPTION
Working back through msdf-atlas-gen tree - the submodule version there will be bumped in a subsequent PR.

We may need a freetype fork to place similar fixes there.